### PR TITLE
fix(ContextExtension): update permissions handling for Android Q and …

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
+        tools:ignore="ScopedStorage" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/app/src/main/java/me/rosuh/easywatermark/utils/ktx/ContextExtension.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/utils/ktx/ContextExtension.kt
@@ -46,12 +46,11 @@ fun Activity.checkWritingPermission(
     },
     grant: () -> Unit,
 ) {
-    val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        Manifest.permission.READ_MEDIA_IMAGES
-    } else {
-        Manifest.permission.WRITE_EXTERNAL_STORAGE
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        grant.invoke()
+        return
     }
-    preCheckStoragePermission(activityResultLauncher, permissions, failed, grant)
+    preCheckStoragePermission(activityResultLauncher, Manifest.permission.WRITE_EXTERNAL_STORAGE, failed, grant)
 }
 
 fun Activity.preCheckStoragePermission(

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,4 +31,4 @@ android.nonFinalResIds=false
 
 majorVersion=2
 minorVersion=9
-patchVersion=3
+patchVersion=4


### PR DESCRIPTION
…above (fix #337)

Refactored the permissions check logic to correctly handle scoped storage for devices running Android Q and later. Removed redundant code and ensured proper invocation of permission grants.

# GENERATE BY https://aicommit.app