### PR TITLE
refactor(build): remove dynamic version calculation from build script…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,10 +101,7 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
       - name: Set version from properties
         run: |
-          majorVersion=$(grep 'majorVersion=' gradle.properties | cut -d'=' -f2)
-          minorVersion=$(grep 'minorVersion=' gradle.properties | cut -d'=' -f2)
-          patchVersion=$(grep 'patchVersion=' gradle.properties | cut -d'=' -f2)
-          version="${majorVersion}.${minorVersion}.${patchVersion}"
+          version=$(grep 'versionName = ' app/build.gradle.kts | awk -F'"' '{print $2}')
           echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
       - name: Publish release.
         if: success()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,21 +9,6 @@ plugins {
     id(libs.plugins.spotless.get().pluginId)
 }
 
-/**
- * read version from gradle.properties
- */
-val majorVersion by properties
-val minorVersion by properties
-val patchVersion by properties
-
-fun getVersionCode(): Int {
-    return (majorVersion as String).toInt() * 10000 + (minorVersion as String).toInt() * 100 + (patchVersion as String).toInt()
-}
-
-fun getVersionName(): String {
-    return "$majorVersion.$minorVersion.$patchVersion"
-}
-
 android {
     compileSdk = (Apps.compileSdk)
     buildToolsVersion = (Apps.buildTools)
@@ -31,8 +16,8 @@ android {
         applicationId = "me.rosuh.easywatermark"
         minSdk = (Apps.minSdk)
         targetSdk = (Apps.targetSdk)
-        versionCode = getVersionCode()
-        versionName = getVersionName()
+        versionCode = 20905
+        versionName = "2.9.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,3 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 #org.gradle.unsafe.configuration-cache=true
-
-majorVersion=2
-minorVersion=9
-patchVersion=5


### PR DESCRIPTION
…. #31

Removed functions in build.gradle.kts that dynamically calculate versionCode and versionName. Set static values for versionCode and versionName directly. Updated release.yml to retrieve versionName from build.gradle.kts instead of gradle.properties.

> GENERATE BY https://aicommit.app