### PR TITLE
Fix Xiaomi haptic feedback crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- Devices running Android 12L (API level 32) or lower  -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />

--- a/app/src/main/java/me/rosuh/easywatermark/utils/VibrateHelper.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/utils/VibrateHelper.kt
@@ -1,5 +1,6 @@
 package me.rosuh.easywatermark.utils
 
+import android.os.Build
 import android.view.HapticFeedbackConstants
 import android.view.View
 
@@ -9,18 +10,30 @@ class VibrateHelper private constructor() {
     private var cd: Long = 20L
 
     fun doVibrate(view: View) {
-        if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
             return
         }
-        if (System.currentTimeMillis() - latestVibration <= cd) {
+        val now = System.currentTimeMillis()
+        if (now - latestVibration <= cd) {
             return
         }
-        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+        latestVibration = now
+        performHapticFeedbackSafely {
+            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+        }
     }
 
     companion object {
         fun get(): VibrateHelper {
             return VibrateHelper()
+        }
+
+        internal fun performHapticFeedbackSafely(performFeedback: () -> Boolean): Boolean {
+            return try {
+                performFeedback()
+            } catch (_: SecurityException) {
+                false
+            }
         }
     }
 }

--- a/app/src/test/java/me/rosuh/easywatermark/utils/VibrateHelperTest.kt
+++ b/app/src/test/java/me/rosuh/easywatermark/utils/VibrateHelperTest.kt
@@ -1,0 +1,22 @@
+package me.rosuh.easywatermark.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VibrateHelperTest {
+    @Test
+    fun performHapticFeedbackSafelyReturnsFalseWhenPermissionIsDenied() {
+        val result = VibrateHelper.performHapticFeedbackSafely {
+            throw SecurityException("missing android.permission.VIBRATE")
+        }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun performHapticFeedbackSafelyReturnsDelegateResult() {
+        assertTrue(VibrateHelper.performHapticFeedbackSafely { true })
+        assertFalse(VibrateHelper.performHapticFeedbackSafely { false })
+    }
+}


### PR DESCRIPTION
## Summary
- Add android.permission.VIBRATE so Xiaomi/Android 16 haptic feedback paths can reach the vibrator service safely.
- Guard View.performHapticFeedback against SecurityException and make the existing haptic cooldown effective.
- Add a regression test for denied haptic permission handling.

## Release note
- Fixed a Xiaomi/Android 16 haptic feedback crash reported by A**** K***.

## Test plan
- ./gradlew :app:testDebugUnitTest :app:assembleRelease