### PR TITLE
refactor: extract Android watermark renderer seam

### DIFF
--- a/app/src/main/java/me/rosuh/easywatermark/render/WatermarkRenderer.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/render/WatermarkRenderer.kt
@@ -1,0 +1,256 @@
+package me.rosuh.easywatermark.render
+
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Shader
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import androidx.core.graphics.withSave
+import kotlinx.coroutines.withContext
+import me.rosuh.easywatermark.data.model.ImageInfo
+import me.rosuh.easywatermark.data.model.WaterMark
+import me.rosuh.easywatermark.ui.widget.utils.WaterMarkShader
+import kotlin.coroutines.CoroutineContext
+import kotlin.math.max
+
+/**
+ * Android-only watermark renderer seam (CMP plan S2a). Centralizes the CURRENT preview/export
+ * watermark logic that was duplicated across [me.rosuh.easywatermark.ui.widget.WaterMarkImageView]
+ * (preview `onDraw` + companion cell builders) and
+ * [me.rosuh.easywatermark.ui.MainViewModel] `generateImage` (export):
+ *
+ *  - [buildTextShader] / [buildIconShader] — build one watermark cell + its tiling [BitmapShader]
+ *    (legacy Android `StaticLayout` / scaled-bitmap path; cell sizing via commonMain
+ *    [WatermarkGeometry]).
+ *  - [compose] — draw the cell shader over a target canvas: REPEAT tiles a region, CLAMP paints one
+ *    decal at a fractional offset. Preview and export now call the SAME helper.
+ *
+ * This is an EXTRACTION-ONLY slice: the bodies below are moved verbatim from the old call sites, so
+ * rendered pixels are unchanged (guarded by the S0 strict export golden + the S2a composition
+ * equivalence test). It is deliberately **Android-only** (it touches `android.graphics.*`,
+ * `android.text.StaticLayout`, `TextPaint`) and therefore lives in `:app`, NOT `shared/commonMain` —
+ * the platform-neutral renderer is a later, explicitly-approved migration slice. Likewise it keeps
+ * the legacy text path and does NOT adopt `TextMeasurer`/`TextMeasureEnv` in this slice.
+ */
+object WatermarkRenderer {
+
+    /**
+     * Build the text watermark cell + REPEAT/CLAMP [BitmapShader]. Verbatim extraction of the former
+     * `WaterMarkImageView.buildTextBitmapShader` (which now delegates here). Uses legacy
+     * `StaticLayout` + the supplied [textPaint] (configured via `TextPaint.applyConfig`).
+     */
+    suspend fun buildTextShader(
+        imageInfo: ImageInfo,
+        config: WaterMark,
+        textPaint: TextPaint,
+        coroutineContext: CoroutineContext,
+    ): WaterMarkShader? = withContext(coroutineContext) {
+        if (config.text.isBlank()) {
+            return@withContext null
+        }
+        val showDebugRect = config.enableBounds
+        var maxLineWidth = 0
+        val tileMode = config.obtainTileMode()
+        // calculate the max width of all lines
+        config.text.split("\n").forEach {
+            val startIndex = config.text.indexOf(it).coerceAtLeast(0)
+            val lineWidth = textPaint.measureText(
+                config.text,
+                startIndex,
+                (startIndex + it.length).coerceAtMost(config.text.length)
+            ).toInt()
+            maxLineWidth = max(maxLineWidth, lineWidth)
+        }
+
+        val staticLayout =
+            StaticLayout.Builder.obtain(
+                config.text,
+                0,
+                config.text.length,
+                textPaint,
+                maxLineWidth
+            )
+                .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+                .build()
+
+        val textWidth = staticLayout.width.toFloat().coerceAtLeast(1f)
+        val textHeight = staticLayout.height.toFloat().coerceAtLeast(1f)
+
+        // C2a: delegate cell sizing to the shared commonMain engine core (behavior-identical
+        // formulas; pinned by WatermarkCellGoldenTest). Verified rendering parity on-device.
+        val fixWidth = WatermarkGeometry.rotatedCellWidth(textWidth, textHeight, config.degree)
+        val fixHeight = WatermarkGeometry.rotatedCellHeight(textWidth, textHeight, config.degree)
+        val finalWidth = WatermarkGeometry.horizontalGap(fixWidth.toInt(), config.hGap)
+        val finalHeight = WatermarkGeometry.verticalGap(fixHeight.toInt(), config.vGap)
+        val bitmap = Bitmap.createBitmap(finalWidth, finalHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        if (showDebugRect) {
+            val tmpPaint = Paint().apply {
+                color = Color.RED
+                strokeWidth = 1f
+                style = Paint.Style.STROKE
+            }
+            canvas.drawRect(0f, 0f, finalWidth.toFloat(), finalHeight.toFloat(), tmpPaint)
+            canvas.save()
+        }
+        // rotate by user input
+        canvas.rotate(
+            config.degree,
+            (finalWidth / 2).toFloat(),
+            (finalHeight / 2).toFloat()
+        )
+        // draw text
+        canvas.withSave {
+            this.translate(
+                ((finalWidth) / 2).toFloat(),
+                ((finalHeight - staticLayout.getLineBottom(0) - staticLayout.getLineTop(0)) / 2).toFloat()
+            )
+            staticLayout.draw(canvas)
+        }
+
+        if (showDebugRect) {
+            canvas.restore()
+        }
+        val bitmapShader = BitmapShader(
+            bitmap,
+            tileMode,
+            tileMode
+        )
+        return@withContext WaterMarkShader(
+            bitmapShader,
+            bitmap.width,
+            bitmap.height
+        )
+    }
+
+    /**
+     * Build the icon watermark cell + REPEAT/CLAMP [BitmapShader]. Verbatim extraction of the former
+     * `WaterMarkImageView.buildIconBitmapShader` (which now delegates here). Preserves the legacy
+     * nearest-neighbor `Bitmap.createScaledBitmap(..., false)` behavior.
+     */
+    suspend fun buildIconShader(
+        imageInfo: ImageInfo,
+        srcBitmap: Bitmap,
+        config: WaterMark,
+        textPaint: Paint,
+        scale: Boolean,
+        coroutineContext: CoroutineContext,
+    ): WaterMarkShader? = withContext(coroutineContext) {
+        if (srcBitmap.isRecycled) {
+            return@withContext null
+        }
+        val tileMode = config.obtainTileMode()
+        val showDebugRect = config.enableBounds
+        val rawWidth = srcBitmap.width.toFloat().coerceAtLeast(1f)
+        val rawHeight = srcBitmap.height.toFloat().coerceAtLeast(1f)
+
+        // C2a: icon-cell sizing via the shared commonMain engine core (equivalence pinned by
+        // WatermarkCellGoldenTest.iconCell_dimensions_match_geometry).
+        val maxSize = WatermarkGeometry.diagonal(rawHeight, rawWidth)
+        val finalWidth = WatermarkGeometry.horizontalGap(maxSize, config.hGap)
+        val finalHeight = WatermarkGeometry.verticalGap(maxSize, config.vGap)
+        // textSize represents scale ratio of icon.
+        val scaleRatio = if (scale) {
+            imageInfo.scaleX
+        } else {
+            1f
+        } * config.textSize / 14f
+
+        val targetBitmap = Bitmap.createBitmap(
+            (finalWidth * scaleRatio).toInt(),
+            (finalHeight * scaleRatio).toInt(),
+            Bitmap.Config.ARGB_8888
+        )
+
+        val canvas = Canvas(targetBitmap)
+
+        val scaleBitmap = Bitmap.createScaledBitmap(
+            srcBitmap,
+            (rawWidth * scaleRatio).toInt(), (rawHeight * scaleRatio).toInt(),
+            false
+        )
+
+        if (showDebugRect) {
+            val tmpPaint = Paint().apply {
+                color = Color.RED
+                strokeWidth = 1f
+                style = Paint.Style.STROKE
+            }
+            canvas.drawRect(0f, 0f, finalWidth * scaleRatio, finalHeight * scaleRatio, tmpPaint)
+            canvas.save()
+        }
+        canvas.rotate(
+            config.degree,
+            (finalWidth * scaleRatio / 2),
+            (finalHeight * scaleRatio / 2)
+        )
+
+        canvas.drawBitmap(
+            scaleBitmap,
+            (finalWidth * scaleRatio - scaleBitmap.width) / 2.toFloat(),
+            (finalHeight * scaleRatio - scaleBitmap.height) / 2.toFloat(),
+            textPaint
+        )
+        if (showDebugRect) {
+            canvas.restore()
+        }
+        val bitmapShader = BitmapShader(
+            targetBitmap,
+            tileMode,
+            tileMode
+        )
+        return@withContext WaterMarkShader(
+            bitmapShader,
+            targetBitmap.width,
+            targetBitmap.height
+        )
+    }
+
+    /**
+     * Draw the watermark cell [shader] over [canvas] — the composition step shared by preview
+     * (`onDraw`) and export (`generateImage`). Verbatim unification of the two former branches:
+     *
+     *  - REPEAT: `translate(left, top)` then fill `[regionWidth] x [regionHeight]` (the whole
+     *    image/drawable region is tiled).
+     *  - CLAMP : `translate(left + offsetX*regionWidth, top + offsetY*regionHeight)` then draw ONE
+     *    cell-sized decal (`shader.width x shader.height`).
+     *
+     * Preview passes the drawable bounds (`left=drawableBounds.left, top=drawableBounds.top,
+     * region=drawableBounds.width()/height()`); export passes `left=0, top=0, region=bitmap size`
+     * (its REPEAT branch had no translate — `translate(0,0)` is a no-op, so behavior is identical).
+     * The null-shader edge cases (CLAMP → 0x0 rect; REPEAT → paint fills the region) are preserved.
+     */
+    fun compose(
+        canvas: Canvas,
+        shader: WaterMarkShader?,
+        tileMode: Shader.TileMode,
+        paint: Paint,
+        left: Float,
+        top: Float,
+        regionWidth: Float,
+        regionHeight: Float,
+        offsetX: Float,
+        offsetY: Float,
+    ) {
+        paint.shader = shader?.bitmapShader
+        canvas.withSave {
+            if (tileMode == Shader.TileMode.CLAMP) {
+                translate(left + offsetX * regionWidth, top + offsetY * regionHeight)
+                drawRect(
+                    0f,
+                    0f,
+                    (shader?.width ?: 0).toFloat(),
+                    (shader?.height ?: 0).toFloat(),
+                    paint
+                )
+            } else {
+                translate(left, top)
+                drawRect(0f, 0f, regionWidth, regionHeight, paint)
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rosuh/easywatermark/ui/MainViewModel.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/ui/MainViewModel.kt
@@ -11,7 +11,6 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
-import android.graphics.Shader
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -54,6 +53,7 @@ import me.rosuh.easywatermark.data.model.ViewInfo
 import me.rosuh.easywatermark.data.model.WaterMark
 import me.rosuh.easywatermark.data.model.WatermarkTileMode
 import me.rosuh.easywatermark.data.model.entity.Template
+import me.rosuh.easywatermark.render.WatermarkRenderer
 import me.rosuh.easywatermark.data.repo.MemorySettingRepo
 import me.rosuh.easywatermark.data.repo.TemplateRepository
 import me.rosuh.easywatermark.data.repo.UserConfigRepository
@@ -327,9 +327,11 @@ class MainViewModel (
             imageInfo.scaleY = 1 / matrixValues[Matrix.MSCALE_X]
             val bitmapPaint = TextPaint().applyConfig(imageInfo, tmpConfig, isScale = false)
             val layoutPaint = Paint()
+            // S2a: build the cell shader through the Android renderer seam (same seam the preview
+            // path uses via WaterMarkImageView's companion wrappers).
             val shader = when (waterMark.value?.markMode) {
                 WaterMarkRepository.MarkMode.Text -> {
-                    WaterMarkImageView.buildTextBitmapShader(
+                    WatermarkRenderer.buildTextShader(
                         imageInfo,
                         waterMark.value!!,
                         bitmapPaint,
@@ -352,7 +354,7 @@ class MainViewModel (
                         )
                     }
                     val iconBitmap = iconBitmapRect.data!!.bitmap
-                    WaterMarkImageView.buildIconBitmapShader(
+                    WatermarkRenderer.buildIconShader(
                         imageInfo,
                         iconBitmap,
                         tmpConfig,
@@ -369,29 +371,21 @@ class MainViewModel (
                 )
             }
 
-            layoutPaint.shader = shader?.bitmapShader
-
-            if (tmpConfig.obtainTileMode() == Shader.TileMode.CLAMP) {
-                canvas.translate(
-                    0 + imageInfo.offsetX * mutableBitmap.width,
-                    0 + imageInfo.offsetY * mutableBitmap.height
-                )
-                canvas.drawRect(
-                    0f,
-                    0f,
-                    (shader?.width ?: 0).toFloat(),
-                    (shader?.height ?: 0).toFloat(),
-                    layoutPaint
-                )
-            } else {
-                canvas.drawRect(
-                    0f,
-                    0f,
-                    mutableBitmap.width.toFloat(),
-                    mutableBitmap.height.toFloat(),
-                    layoutPaint
-                )
-            }
+            // S2a: composition delegated to the shared renderer seam (same helper as preview).
+            // Export composites at the bitmap origin (left/top = 0, region = full bitmap); the old
+            // REPEAT branch had no canvas translate, which `compose` reproduces as translate(0,0).
+            WatermarkRenderer.compose(
+                canvas = canvas,
+                shader = shader,
+                tileMode = tmpConfig.obtainTileMode(),
+                paint = layoutPaint,
+                left = 0f,
+                top = 0f,
+                regionWidth = mutableBitmap.width.toFloat(),
+                regionHeight = mutableBitmap.height.toFloat(),
+                offsetX = imageInfo.offsetX,
+                offsetY = imageInfo.offsetY,
+            )
 
             return@withContext if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 val imageCollection =

--- a/app/src/main/java/me/rosuh/easywatermark/ui/widget/WaterMarkImageView.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/ui/widget/WaterMarkImageView.kt
@@ -5,7 +5,6 @@ import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapShader
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Matrix
@@ -13,15 +12,12 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Shader
 import android.net.Uri
-import android.text.Layout
-import android.text.StaticLayout
 import android.text.TextPaint
 import android.util.AttributeSet
 import android.util.Log
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import androidx.core.animation.doOnEnd
-import androidx.core.graphics.withSave
 import androidx.palette.graphics.Palette
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -34,7 +30,7 @@ import kotlinx.coroutines.withContext
 import me.rosuh.easywatermark.data.model.ImageInfo
 import me.rosuh.easywatermark.data.model.ViewInfo
 import me.rosuh.easywatermark.data.model.WaterMark
-import me.rosuh.easywatermark.render.WatermarkGeometry
+import me.rosuh.easywatermark.render.WatermarkRenderer
 import me.rosuh.easywatermark.data.repo.WaterMarkRepository
 import me.rosuh.easywatermark.data.repo.WaterMarkRepository.Companion.DEFAULT_TEXT_SIZE
 import me.rosuh.easywatermark.data.repo.WaterMarkRepository.Companion.MAX_TEXT_SIZE
@@ -48,7 +44,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.math.abs
 import kotlin.math.absoluteValue
 import kotlin.math.cos
-import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sin
@@ -297,31 +292,19 @@ class WaterMarkImageView : androidx.appcompat.widget.AppCompatImageView, Corouti
         ) {
             return
         }
-        layoutPaint.shader = layoutShader?.bitmapShader
-        canvas.withSave {
-            if (config?.obtainTileMode() == Shader.TileMode.CLAMP) {
-                translate(
-                    drawableBounds.left + curImageInfo.offsetX * drawableBounds.width(),
-                    drawableBounds.top + curImageInfo.offsetY * drawableBounds.height()
-                )
-                drawRect(
-                    0f,
-                    0f,
-                    (layoutShader?.width ?: 0).toFloat(),
-                    (layoutShader?.height ?: 0).toFloat(),
-                    layoutPaint
-                )
-            } else {
-                translate(drawableBounds.left, drawableBounds.top)
-                drawRect(
-                    0f,
-                    0f,
-                    drawableBounds.right - drawableBounds.left,
-                    drawableBounds.bottom - drawableBounds.top,
-                    layoutPaint
-                )
-            }
-        }
+        // S2a: composition delegated to the shared renderer seam (same helper as export).
+        WatermarkRenderer.compose(
+            canvas = canvas,
+            shader = layoutShader,
+            tileMode = config?.obtainTileMode() ?: Shader.TileMode.REPEAT,
+            paint = layoutPaint,
+            left = drawableBounds.left,
+            top = drawableBounds.top,
+            regionWidth = drawableBounds.width(),
+            regionHeight = drawableBounds.height(),
+            offsetX = curImageInfo.offsetX,
+            offsetY = curImageInfo.offsetY,
+        )
     }
 
     private fun generateDrawableBounds() {
@@ -589,6 +572,11 @@ class WaterMarkImageView : androidx.appcompat.widget.AppCompatImageView, Corouti
 
         fun calculateDrawLimitHeight(h: Int, pt: Int) = (h - pt * 2)
 
+        /**
+         * S2a: compatibility wrapper. The icon-cell builder body now lives in the Android renderer
+         * seam [WatermarkRenderer.buildIconShader]; this wrapper is retained so existing call sites
+         * and goldens (which reference `WaterMarkImageView.buildIconBitmapShader`) stay unchanged.
+         */
         suspend fun buildIconBitmapShader(
             imageInfo: ImageInfo,
             srcBitmap: Bitmap,
@@ -596,165 +584,22 @@ class WaterMarkImageView : androidx.appcompat.widget.AppCompatImageView, Corouti
             textPaint: Paint,
             scale: Boolean,
             coroutineContext: CoroutineContext,
-        ): WaterMarkShader? = withContext(coroutineContext) {
-            if (srcBitmap.isRecycled) {
-                return@withContext null
-            }
-            val tileMode = config.obtainTileMode()
-            val showDebugRect = config.enableBounds
-            val rawWidth = srcBitmap.width.toFloat().coerceAtLeast(1f)
-            val rawHeight = srcBitmap.height.toFloat().coerceAtLeast(1f)
-
-            // C2a: icon-cell sizing via the shared commonMain engine core (equivalence pinned by
-            // WatermarkCellGoldenTest.iconCell_dimensions_match_geometry).
-            val maxSize = WatermarkGeometry.diagonal(rawHeight, rawWidth)
-            val finalWidth = WatermarkGeometry.horizontalGap(maxSize, config.hGap)
-            val finalHeight = WatermarkGeometry.verticalGap(maxSize, config.vGap)
-            // textSize represents scale ratio of icon.
-            val scaleRatio = if (scale) {
-                imageInfo.scaleX
-            } else {
-                1f
-            } * config.textSize / 14f
-
-            val targetBitmap = Bitmap.createBitmap(
-                (finalWidth * scaleRatio).toInt(),
-                (finalHeight * scaleRatio).toInt(),
-                Bitmap.Config.ARGB_8888
+        ): WaterMarkShader? =
+            WatermarkRenderer.buildIconShader(
+                imageInfo, srcBitmap, config, textPaint, scale, coroutineContext
             )
-
-            val canvas = Canvas(targetBitmap)
-
-            val scaleBitmap = Bitmap.createScaledBitmap(
-                srcBitmap,
-                (rawWidth * scaleRatio).toInt(), (rawHeight * scaleRatio).toInt(),
-                false
-            )
-
-            if (showDebugRect) {
-                val tmpPaint = Paint().apply {
-                    color = Color.RED
-                    strokeWidth = 1f
-                    style = Paint.Style.STROKE
-                }
-                canvas.drawRect(0f, 0f, finalWidth * scaleRatio, finalHeight * scaleRatio, tmpPaint)
-                canvas.save()
-            }
-            canvas.rotate(
-                config.degree,
-                (finalWidth * scaleRatio / 2),
-                (finalHeight * scaleRatio / 2)
-            )
-
-            canvas.drawBitmap(
-                scaleBitmap,
-                (finalWidth * scaleRatio - scaleBitmap.width) / 2.toFloat(),
-                (finalHeight * scaleRatio - scaleBitmap.height) / 2.toFloat(),
-                textPaint
-            )
-            if (showDebugRect) {
-                canvas.restore()
-            }
-            val bitmapShader = BitmapShader(
-                targetBitmap,
-                tileMode,
-                tileMode
-            )
-            return@withContext WaterMarkShader(
-                bitmapShader,
-                targetBitmap.width,
-                targetBitmap.height
-            )
-        }
 
         /**
-         * Generate bitmap shader from input text.
-         * Text watermark implemented by bitmap shader.
-         * Using [StaticLayout] to draw multi line text.
-         * @author hi@rosuh.me
+         * S2a: compatibility wrapper. The text-cell builder body now lives in the Android renderer
+         * seam [WatermarkRenderer.buildTextShader]; this wrapper is retained so existing call sites
+         * and goldens (which reference `WaterMarkImageView.buildTextBitmapShader`) stay unchanged.
          */
         suspend fun buildTextBitmapShader(
             imageInfo: ImageInfo,
             config: WaterMark,
             textPaint: TextPaint,
             coroutineContext: CoroutineContext,
-        ): WaterMarkShader? = withContext(coroutineContext) {
-            if (config.text.isBlank()) {
-                return@withContext null
-            }
-            val showDebugRect = config.enableBounds
-            var maxLineWidth = 0
-            val tileMode = config.obtainTileMode()
-            // calculate the max width of all lines
-            config.text.split("\n").forEach {
-                val startIndex = config.text.indexOf(it).coerceAtLeast(0)
-                val lineWidth = textPaint.measureText(
-                    config.text,
-                    startIndex,
-                    (startIndex + it.length).coerceAtMost(config.text.length)
-                ).toInt()
-                maxLineWidth = max(maxLineWidth, lineWidth)
-            }
-
-            val staticLayout =
-                StaticLayout.Builder.obtain(
-                    config.text,
-                    0,
-                    config.text.length,
-                    textPaint,
-                    maxLineWidth
-                )
-                    .setAlignment(Layout.Alignment.ALIGN_NORMAL)
-                    .build()
-
-            val textWidth = staticLayout.width.toFloat().coerceAtLeast(1f)
-            val textHeight = staticLayout.height.toFloat().coerceAtLeast(1f)
-
-            // C2a: delegate cell sizing to the shared commonMain engine core (behavior-identical
-            // formulas; pinned by WatermarkCellGoldenTest). Verified rendering parity on-device.
-            val fixWidth = WatermarkGeometry.rotatedCellWidth(textWidth, textHeight, config.degree)
-            val fixHeight = WatermarkGeometry.rotatedCellHeight(textWidth, textHeight, config.degree)
-            val finalWidth = WatermarkGeometry.horizontalGap(fixWidth.toInt(), config.hGap)
-            val finalHeight = WatermarkGeometry.verticalGap(fixHeight.toInt(), config.vGap)
-            val bitmap = Bitmap.createBitmap(finalWidth, finalHeight, Bitmap.Config.ARGB_8888)
-            val canvas = Canvas(bitmap)
-            if (showDebugRect) {
-                val tmpPaint = Paint().apply {
-                    color = Color.RED
-                    strokeWidth = 1f
-                    style = Paint.Style.STROKE
-                }
-                canvas.drawRect(0f, 0f, finalWidth.toFloat(), finalHeight.toFloat(), tmpPaint)
-                canvas.save()
-            }
-            // rotate by user input
-            canvas.rotate(
-                config.degree,
-                (finalWidth / 2).toFloat(),
-                (finalHeight / 2).toFloat()
-            )
-            // draw text
-            canvas.withSave {
-                this.translate(
-                    ((finalWidth) / 2).toFloat(),
-                    ((finalHeight - staticLayout.getLineBottom(0) - staticLayout.getLineTop(0)) / 2).toFloat()
-                )
-                staticLayout.draw(canvas)
-            }
-
-            if (showDebugRect) {
-                canvas.restore()
-            }
-            val bitmapShader = BitmapShader(
-                bitmap,
-                tileMode,
-                tileMode
-            )
-            return@withContext WaterMarkShader(
-                bitmapShader,
-                bitmap.width,
-                bitmap.height
-            )
-        }
+        ): WaterMarkShader? =
+            WatermarkRenderer.buildTextShader(imageInfo, config, textPaint, coroutineContext)
     }
 }

--- a/app/src/test/java/me/rosuh/easywatermark/render/WatermarkRendererCompositionTest.kt
+++ b/app/src/test/java/me/rosuh/easywatermark/render/WatermarkRendererCompositionTest.kt
@@ -1,0 +1,157 @@
+package me.rosuh.easywatermark.render
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Shader
+import android.net.Uri
+import android.text.TextPaint
+import androidx.core.graphics.withSave
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import me.rosuh.easywatermark.data.model.ImageInfo
+import me.rosuh.easywatermark.data.model.WaterMark
+import me.rosuh.easywatermark.data.model.WatermarkTileMode
+import me.rosuh.easywatermark.ui.widget.utils.WaterMarkShader
+import me.rosuh.easywatermark.utils.ktx.applyConfig
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * S2a extraction proof for the composition helper. Pins that the unified
+ * [WatermarkRenderer.compose] reproduces — pixel-for-pixel — the two former, separate composition
+ * branches it replaced:
+ *
+ *  - the EXPORT branch in `MainViewModel.generateImage` (no `withSave`, no translate for REPEAT,
+ *    composited at canvas origin), and
+ *  - the PREVIEW branch in `WaterMarkImageView.onDraw` (`withSave`, translate by drawable bounds).
+ *
+ * The cell-builder extraction (`buildTextShader`/`buildIconShader`) is guarded separately by the S0
+ * strict export golden via the retained `WaterMarkImageView.build*BitmapShader` wrappers.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WatermarkRendererCompositionTest {
+
+    private fun buildShader(tile: WatermarkTileMode): WaterMarkShader {
+        val imageInfo = ImageInfo.empty().apply { width = 1000; height = 1000 }
+        val config = WaterMark.default.copy(
+            text = "GOLDEN", degree = 0f, hGap = 0, vGap = 0,
+            textSize = 24f, textColor = Color.WHITE, iconUri = Uri.EMPTY, tileMode = tile,
+        )
+        val paint = TextPaint().applyConfig(imageInfo, config, isScale = false)
+        return runBlocking {
+            WatermarkRenderer.buildTextShader(imageInfo, config, paint, Dispatchers.Unconfined)
+        }!!
+    }
+
+    private fun newBitmap(bg: Int, w: Int = 200, h: Int = 200): Bitmap =
+        Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888).apply { eraseColor(bg) }
+
+    private fun pixels(b: Bitmap): IntArray =
+        IntArray(b.width * b.height).also { b.getPixels(it, 0, b.width, 0, 0, b.width, b.height) }
+
+    /** Verbatim copy of the PRE-S2a export composition (MainViewModel.generateImage ~lines 372-394). */
+    private fun oldExportCompose(
+        canvas: Canvas, shader: WaterMarkShader?, tile: Shader.TileMode, paint: Paint,
+        bmpW: Int, bmpH: Int, offsetX: Float, offsetY: Float,
+    ) {
+        paint.shader = shader?.bitmapShader
+        if (tile == Shader.TileMode.CLAMP) {
+            canvas.translate(0 + offsetX * bmpW, 0 + offsetY * bmpH)
+            canvas.drawRect(0f, 0f, (shader?.width ?: 0).toFloat(), (shader?.height ?: 0).toFloat(), paint)
+        } else {
+            canvas.drawRect(0f, 0f, bmpW.toFloat(), bmpH.toFloat(), paint)
+        }
+    }
+
+    /** Verbatim copy of the PRE-S2a preview composition (WaterMarkImageView.onDraw ~lines 300-324). */
+    private fun oldPreviewCompose(
+        canvas: Canvas, shader: WaterMarkShader?, tile: Shader.TileMode, paint: Paint,
+        left: Float, top: Float, regionW: Float, regionH: Float, offsetX: Float, offsetY: Float,
+    ) {
+        paint.shader = shader?.bitmapShader
+        canvas.withSave {
+            if (tile == Shader.TileMode.CLAMP) {
+                translate(left + offsetX * regionW, top + offsetY * regionH)
+                drawRect(0f, 0f, (shader?.width ?: 0).toFloat(), (shader?.height ?: 0).toFloat(), paint)
+            } else {
+                translate(left, top)
+                drawRect(0f, 0f, regionW, regionH, paint)
+            }
+        }
+    }
+
+    // ---- export-shape equivalence (left/top = 0, region = full bitmap) -------------------------
+
+    @Test
+    fun compose_matches_legacy_export_repeat() {
+        val shader = buildShader(WatermarkTileMode.REPEAT)
+        val a = newBitmap(Color.DKGRAY)
+        WatermarkRenderer.compose(Canvas(a), shader, Shader.TileMode.REPEAT, Paint(), 0f, 0f, 200f, 200f, 0.3f, 0.4f)
+        val b = newBitmap(Color.DKGRAY)
+        oldExportCompose(Canvas(b), shader, Shader.TileMode.REPEAT, Paint(), 200, 200, 0.3f, 0.4f)
+        assertArrayEquals(pixels(b), pixels(a))
+    }
+
+    @Test
+    fun compose_matches_legacy_export_clamp() {
+        val shader = buildShader(WatermarkTileMode.CLAMP)
+        val a = newBitmap(Color.DKGRAY)
+        WatermarkRenderer.compose(Canvas(a), shader, Shader.TileMode.CLAMP, Paint(), 0f, 0f, 200f, 200f, 0.3f, 0.4f)
+        val b = newBitmap(Color.DKGRAY)
+        oldExportCompose(Canvas(b), shader, Shader.TileMode.CLAMP, Paint(), 200, 200, 0.3f, 0.4f)
+        assertArrayEquals(pixels(b), pixels(a))
+    }
+
+    // ---- preview-shape equivalence (non-zero left/top, region = drawable bounds) ---------------
+
+    @Test
+    fun compose_matches_legacy_preview_repeat() {
+        val shader = buildShader(WatermarkTileMode.REPEAT)
+        val a = newBitmap(Color.DKGRAY)
+        WatermarkRenderer.compose(Canvas(a), shader, Shader.TileMode.REPEAT, Paint(), 10f, 20f, 180f, 160f, 0.3f, 0.4f)
+        val b = newBitmap(Color.DKGRAY)
+        oldPreviewCompose(Canvas(b), shader, Shader.TileMode.REPEAT, Paint(), 10f, 20f, 180f, 160f, 0.3f, 0.4f)
+        assertArrayEquals(pixels(b), pixels(a))
+    }
+
+    @Test
+    fun compose_matches_legacy_preview_clamp() {
+        val shader = buildShader(WatermarkTileMode.CLAMP)
+        val a = newBitmap(Color.DKGRAY)
+        WatermarkRenderer.compose(Canvas(a), shader, Shader.TileMode.CLAMP, Paint(), 10f, 20f, 180f, 160f, 0.3f, 0.4f)
+        val b = newBitmap(Color.DKGRAY)
+        oldPreviewCompose(Canvas(b), shader, Shader.TileMode.CLAMP, Paint(), 10f, 20f, 180f, 160f, 0.3f, 0.4f)
+        assertArrayEquals(pixels(b), pixels(a))
+    }
+
+    // ---- null-shader edge quirks preserved -----------------------------------------------------
+
+    @Test
+    fun compose_matches_legacy_export_null_shader_repeat_fills_with_paint() {
+        // Quirk: REPEAT with a null shader fills the whole region with the (default black) paint.
+        val a = newBitmap(Color.DKGRAY)
+        WatermarkRenderer.compose(Canvas(a), null, Shader.TileMode.REPEAT, Paint(), 0f, 0f, 200f, 200f, 0.3f, 0.4f)
+        val b = newBitmap(Color.DKGRAY)
+        oldExportCompose(Canvas(b), null, Shader.TileMode.REPEAT, Paint(), 200, 200, 0.3f, 0.4f)
+        assertArrayEquals(pixels(b), pixels(a))
+    }
+
+    @Test
+    fun compose_matches_legacy_export_null_shader_clamp_draws_nothing() {
+        // Quirk: CLAMP with a null shader draws a 0x0 rect -> background untouched.
+        val a = newBitmap(Color.DKGRAY)
+        WatermarkRenderer.compose(Canvas(a), null, Shader.TileMode.CLAMP, Paint(), 0f, 0f, 200f, 200f, 0.3f, 0.4f)
+        val b = newBitmap(Color.DKGRAY)
+        oldExportCompose(Canvas(b), null, Shader.TileMode.CLAMP, Paint(), 200, 200, 0.3f, 0.4f)
+        assertArrayEquals(pixels(b), pixels(a))
+    }
+}


### PR DESCRIPTION
## Summary
- add Android-only `WatermarkRenderer` seam for current text/icon shader building and CLAMP/REPEAT composition
- delegate `WaterMarkImageView` preview composition and `MainViewModel.generateImage` export composition to the seam
- keep legacy `StaticLayout` text path, compatibility wrappers, existing scale quirk, and S0/CJK/TileMode/DataStore behavior unchanged
- add `WatermarkRendererCompositionTest` covering export/preview composition equivalence and null-shader quirks

## Verification
- `WATERMARK_GOLDEN_STRICT=true ./gradlew :app:testDebugUnitTest --tests 'me.rosuh.easywatermark.render.WatermarkExportGoldenTest' --max-workers=8 --console=plain --rerun-tasks && git diff --check`\n- `./gradlew :shared:desktopTest :app:testDebugUnitTest :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin --max-workers=8 --console=plain`\n\nACSP coordinator review accepted: `20260614-164003--s2a-watermark-renderer-extraction`.\n