### PR TITLE
[codex] Implement image-space text sizing

### DIFF
--- a/app/src/main/java/me/rosuh/easywatermark/render/WatermarkRenderer.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/render/WatermarkRenderer.kt
@@ -39,6 +39,32 @@ import kotlin.math.max
 object WatermarkRenderer {
 
     /**
+     * S3a image-space sizing reference width (px). `textSize` is interpreted as image-space:
+     *
+     * ```
+     * textPx = textSize * imageWidth / REF_WIDTH
+     * ```
+     *
+     * where `imageWidth` is the width of the bitmap the watermark cell tiles over (the displayed
+     * drawable in preview, the full source image at export — both already carried by
+     * `ImageInfo.width`). This makes the watermark a constant fraction (`textSize / REF_WIDTH`) of the
+     * image on every device and in both preview and export, replacing the old, device-dependent,
+     * un-persisted preview-matrix scale (`1/MSCALE_X`).
+     *
+     * **Why 1000:** it is the canonical reference image width already used by every existing
+     * golden/gate in this repo (`WatermarkExportGoldenTest`, `WatermarkCellGoldenTest`,
+     * `WatermarkCellInstrumentedGoldenTest`, `WatermarkCellParityGateTest` all use
+     * `ImageInfo.width = 1000`). At that reference width the formula reproduces the legacy unscaled
+     * paint size exactly (`textSize * 1000 / 1000 == textSize`), so `textSize` keeps its historical
+     * meaning at the reference and scales proportionally elsewhere. 1000 is also representative of a
+     * typical editor preview-canvas width on the dominant ~1080px-wide phone class (canvas = screen −
+     * padding ≈ 1000), so the typical user's export size is approximately preserved — the bounded
+     * one-time shift accepted under D3 Option A (see ACSP ref-width-decision.md). A precise
+     * production-preview-width recalibration on the authority device is a later optional refinement.
+     */
+    const val REF_WIDTH: Float = 1000f
+
+    /**
      * Build the text watermark cell + REPEAT/CLAMP [BitmapShader]. Verbatim extraction of the former
      * `WaterMarkImageView.buildTextBitmapShader` (which now delegates here). Uses legacy
      * `StaticLayout` + the supplied [textPaint] (configured via `TextPaint.applyConfig`).
@@ -133,11 +159,11 @@ object WatermarkRenderer {
      * nearest-neighbor `Bitmap.createScaledBitmap(..., false)` behavior.
      */
     suspend fun buildIconShader(
-        imageInfo: ImageInfo,
+        @Suppress("UNUSED_PARAMETER") imageInfo: ImageInfo, // S3a: icon no longer reads scaleX; kept for API compatibility
         srcBitmap: Bitmap,
         config: WaterMark,
         textPaint: Paint,
-        scale: Boolean,
+        @Suppress("UNUSED_PARAMETER") scale: Boolean, // S3a: view-scale coupling removed; param kept for source/API compatibility
         coroutineContext: CoroutineContext,
     ): WaterMarkShader? = withContext(coroutineContext) {
         if (srcBitmap.isRecycled) {
@@ -153,12 +179,10 @@ object WatermarkRenderer {
         val maxSize = WatermarkGeometry.diagonal(rawHeight, rawWidth)
         val finalWidth = WatermarkGeometry.horizontalGap(maxSize, config.hGap)
         val finalHeight = WatermarkGeometry.verticalGap(maxSize, config.vGap)
-        // textSize represents scale ratio of icon.
-        val scaleRatio = if (scale) {
-            imageInfo.scaleX
-        } else {
-            1f
-        } * config.textSize / 14f
+        // S3a: `textSize` is the icon scale ratio (textSize/14 ⇒ 14 = 1×), preserved from legacy.
+        // The old preview-matrix `imageInfo.scaleX` factor (applied only at export, `scale=true`) is
+        // REMOVED so preview and export size icons identically and independent of view scale (D2c).
+        val scaleRatio = config.textSize / 14f
 
         val targetBitmap = Bitmap.createBitmap(
             (finalWidth * scaleRatio).toInt(),

--- a/app/src/main/java/me/rosuh/easywatermark/utils/ktx/PainKtx.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/utils/ktx/PainKtx.kt
@@ -6,21 +6,29 @@ import android.graphics.Typeface
 import android.text.TextPaint
 import me.rosuh.easywatermark.data.model.ImageInfo
 import me.rosuh.easywatermark.data.model.WaterMark
+import me.rosuh.easywatermark.render.WatermarkRenderer
 
 /**
- * 因为预览和实际图像之间存在缩放，所以在预览时要除去缩放比。而在保存时，就不需要了
- * Because there is a zoom between the preview and the actual image, the zoom ratio should be removed when previewing
- * When saving, it’s not needed
+ * S3a image-space sizing: the text paint size is `textSize * imageInfo.width / REF_WIDTH`, i.e.
+ * `textSize` is a fraction (`textSize / REF_WIDTH`) of the target image's width, resolved against the
+ * bitmap the cell tiles over (`ImageInfo.width` = the displayed drawable in preview, the full source
+ * image at export). Preview and export now use the SAME formula, so the watermark is the same fraction
+ * of the image regardless of device/preview-view size.
+ *
+ * Replaces the old, device-dependent behavior (`textSize` raw in preview; `textSize * scaleX`, where
+ * `scaleX = 1/MSCALE_X` from the preview matrix, at export). [isScale] is retained for call-site/source
+ * compatibility but **no longer affects sizing** — both modes are image-space. Persisted `textSize`
+ * values are unchanged (D3 Option A, no DataStore migration).
  * @author hi@rosuh.me
- * @date 2020/9/8
+ * @date 2020/9/8 · S3a image-space re-spec 2026-06-14
  */
 fun Paint.applyConfig(
     imageInfo: ImageInfo,
     config: WaterMark?,
-    isScale: Boolean = true
+    @Suppress("UNUSED_PARAMETER") isScale: Boolean = true
 ): Paint {
     val size = config?.textSize ?: 14f
-    textSize = if (isScale) size else size * imageInfo.scaleX
+    textSize = size * imageInfo.width / WatermarkRenderer.REF_WIDTH
     color = config?.textColor ?: Color.RED
     alpha = config?.alpha ?: 128
     style = config?.textStyle?.obtainSysStyle() ?: Paint.Style.FILL

--- a/app/src/test/java/me/rosuh/easywatermark/render/WatermarkImageSpaceSizingTest.kt
+++ b/app/src/test/java/me/rosuh/easywatermark/render/WatermarkImageSpaceSizingTest.kt
@@ -1,0 +1,141 @@
+package me.rosuh.easywatermark.render
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.Paint
+import android.net.Uri
+import android.text.TextPaint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import me.rosuh.easywatermark.data.model.ImageInfo
+import me.rosuh.easywatermark.data.model.WaterMark
+import me.rosuh.easywatermark.ui.widget.utils.WaterMarkShader
+import me.rosuh.easywatermark.utils.ktx.applyConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * S3a — image-space `textSize` behavior. `textPx = textSize * imageInfo.width / REF_WIDTH`
+ * (`WatermarkRenderer.REF_WIDTH = 1000`). These tests pin the NEW behavior and **fail on the old
+ * view-scale-dependent behavior**:
+ *  - old text: `textSize` raw (preview) / `textSize * imageInfo.scaleX` (export) — depended on the
+ *    preview matrix and ignored image width;
+ *  - old icon: `(scale ? imageInfo.scaleX : 1) * textSize/14` — depended on view scale at export.
+ *
+ * The new behavior is independent of `imageInfo.scaleX` and of the `isScale`/`scale` flags, and scales
+ * linearly with `imageInfo.width`. At the reference width (1000, used by every existing golden) the
+ * text paint size equals the legacy unscaled size, so existing goldens are unchanged.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WatermarkImageSpaceSizingTest {
+
+    private fun config(size: Float = 24f) = WaterMark.default.copy(
+        text = "GOLDEN", degree = 0f, hGap = 0, vGap = 0,
+        textSize = size, textColor = Color.WHITE, iconUri = Uri.EMPTY,
+    )
+
+    private fun imageInfo(width: Int, scaleX: Float = 1f) =
+        ImageInfo.empty().apply { this.width = width; this.height = width; this.scaleX = scaleX }
+
+    // ---- direct paint sizing (the precise old-vs-new pin) --------------------------------------
+
+    @Test
+    fun text_paint_size_equals_legacy_at_reference_width() {
+        // At REF_WIDTH=1000 the image-space size reproduces the legacy unscaled paint size exactly.
+        val p = TextPaint().applyConfig(imageInfo(width = 1000), config(size = 24f), isScale = false)
+        assertEquals(24f, p.textSize, 0.001f)
+    }
+
+    @Test
+    fun text_paint_size_scales_linearly_with_image_width() {
+        // 2x image width -> 2x text px. (OLD isScale=true ignored width -> would stay 24f -> fails.)
+        val p1000 = TextPaint().applyConfig(imageInfo(1000), config(24f), isScale = true)
+        val p2000 = TextPaint().applyConfig(imageInfo(2000), config(24f), isScale = true)
+        val p500 = TextPaint().applyConfig(imageInfo(500), config(24f), isScale = true)
+        assertEquals(24f, p1000.textSize, 0.001f)
+        assertEquals(48f, p2000.textSize, 0.001f)
+        assertEquals(12f, p500.textSize, 0.001f)
+    }
+
+    @Test
+    fun text_paint_size_independent_of_view_scaleX() {
+        // OLD export path multiplied by imageInfo.scaleX; new path must ignore it.
+        val a = TextPaint().applyConfig(imageInfo(1000, scaleX = 1f), config(24f), isScale = false)
+        val b = TextPaint().applyConfig(imageInfo(1000, scaleX = 4f), config(24f), isScale = false)
+        assertEquals(a.textSize, b.textSize, 0.001f)
+        assertEquals(24f, b.textSize, 0.001f) // not 24*4
+    }
+
+    @Test
+    fun text_paint_size_independent_of_isScale_flag() {
+        // Preview (isScale=true) and export (isScale=false) now use the SAME formula.
+        val preview = TextPaint().applyConfig(imageInfo(2000, scaleX = 3f), config(24f), isScale = true)
+        val export = TextPaint().applyConfig(imageInfo(2000, scaleX = 3f), config(24f), isScale = false)
+        assertEquals(preview.textSize, export.textSize, 0.001f)
+        assertEquals(48f, export.textSize, 0.001f) // 24 * 2000/1000
+    }
+
+    // ---- rendered text cell end-to-end --------------------------------------------------------
+
+    private fun textCell(width: Int, scaleX: Float, size: Float = 24f): WaterMarkShader {
+        val info = imageInfo(width, scaleX)
+        val paint = TextPaint().applyConfig(info, config(size), isScale = false)
+        return runBlocking {
+            WatermarkRenderer.buildTextShader(info, config(size), paint, Dispatchers.Unconfined)
+        }!!
+    }
+
+    @Test
+    fun text_cell_grows_with_image_width() {
+        val c1000 = textCell(width = 1000, scaleX = 1f)
+        val c2000 = textCell(width = 2000, scaleX = 1f)
+        // ~2x paint size -> ~2x cell (allow rounding slack from .toInt()/StaticLayout).
+        assertTrue("2000px-image cell must be larger", c2000.width > c1000.width && c2000.height > c1000.height)
+        val ratio = c2000.width.toFloat() / c1000.width
+        assertTrue("cell width ratio ~2x (was $ratio)", ratio in 1.8f..2.2f)
+    }
+
+    @Test
+    fun text_cell_independent_of_view_scaleX() {
+        val a = textCell(width = 1000, scaleX = 1f)
+        val b = textCell(width = 1000, scaleX = 5f)
+        assertEquals("cell width must not depend on scaleX", a.width, b.width)
+        assertEquals("cell height must not depend on scaleX", a.height, b.height)
+    }
+
+    // ---- icon cell ----------------------------------------------------------------------------
+
+    private fun iconCell(scale: Boolean, scaleX: Float, size: Float = 14f): WaterMarkShader {
+        val info = imageInfo(1000, scaleX)
+        val src = Bitmap.createBitmap(40, 20, Bitmap.Config.ARGB_8888).apply { eraseColor(Color.WHITE) }
+        return runBlocking {
+            WatermarkRenderer.buildIconShader(info, src, config(size), Paint(), scale, Dispatchers.Unconfined)
+        }!!
+    }
+
+    @Test
+    fun icon_cell_independent_of_view_scale_and_scaleX() {
+        // OLD: scale=true multiplied by imageInfo.scaleX -> bigger at export. NEW: textSize/14 always.
+        val previewLike = iconCell(scale = false, scaleX = 1f)
+        val exportLike = iconCell(scale = true, scaleX = 4f)
+        assertEquals("icon cell must not depend on scale flag/scaleX", previewLike.width, exportLike.width)
+        assertEquals("icon cell must not depend on scale flag/scaleX", previewLike.height, exportLike.height)
+    }
+
+    @Test
+    fun icon_cell_preserves_textsize_over_14_ratio() {
+        // textSize 28 -> 2x of textSize 14 (ratio semantics preserved).
+        val x1 = iconCell(scale = false, scaleX = 1f, size = 14f)
+        val x2 = iconCell(scale = false, scaleX = 1f, size = 28f)
+        val ratio = x2.width.toFloat() / x1.width
+        assertTrue("icon ratio ~2x (was $ratio)", ratio in 1.8f..2.2f)
+    }
+}


### PR DESCRIPTION
## Summary

- Implements S3a image-space `textSize` sizing: `textPx = textSize * imageInfo.width / WatermarkRenderer.REF_WIDTH`.
- Adds documented `WatermarkRenderer.REF_WIDTH = 1000f`, matching the repo reference width used by current goldens/gates.
- Removes view-scale coupling from icon sizing while preserving `textSize / 14` ratio semantics.
- Keeps persisted values unchanged: no DataStore migration/write and no `WaterMarkRepository` changes.
- Adds `WatermarkImageSpaceSizingTest` to pin width scaling and scale independence.

## Scope

- S3a only: D2/D3 accepted behavior.
- No D1 / `TextMeasurer` product wiring.
- No S3b CJK baseline/tolerance changes.
- No S3c preview replacement, `ViewInfo` deletion, or `WaterMarkImageView` removal.
- No golden rebaseline.

## Verification

- `./gradlew :app:testDebugUnitTest --tests 'me.rosuh.easywatermark.render.WatermarkImageSpaceSizingTest' --max-workers=8 --console=plain`
- `./gradlew :shared:desktopTest :app:testDebugUnitTest :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin --max-workers=8 --console=plain`
- `WATERMARK_GOLDEN_STRICT=true ./gradlew :app:testDebugUnitTest --tests 'me.rosuh.easywatermark.render.WatermarkExportGoldenTest' --max-workers=8 --console=plain --rerun-tasks`
- `git diff --check`

## UI Follow-up

UI comparison was not run because the authority device `RFCT414QBMZ` was offline. Recommended PR follow-up: production app first, then debug app on the same image and text sizes; emulator evidence remains supplementary.
