### PR TITLE
S3c-1: Decouple export from preview ViewInfo

### DIFF
--- a/app/src/main/java/me/rosuh/easywatermark/ui/ComposeMainActivity.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/ui/ComposeMainActivity.kt
@@ -60,7 +60,6 @@ import androidx.navigation.compose.rememberNavController
 import me.rosuh.easywatermark.R
 
 import me.rosuh.easywatermark.data.model.FuncTitleModel
-import me.rosuh.easywatermark.data.model.ViewInfo
 import android.widget.Toast
 import me.rosuh.easywatermark.BuildConfig
 import me.rosuh.easywatermark.ui.about.AboutScreen
@@ -234,7 +233,6 @@ class ComposeMainActivity : ComponentActivity() {
                             val userPreferences by viewModel.userPreferences.collectAsStateWithLifecycle()
                             val state by viewModel.launchScreenUiStateFlow.collectAsStateWithLifecycle()
                             val context = LocalContext.current
-                            val viewInfo by viewModel.viewInfoStateFlow.collectAsStateWithLifecycle()
                             val templates by viewModel.templateListFlow.collectAsStateWithLifecycle()
 
                             // [DEBUG] temporary export instrumentation — remove after diagnosing
@@ -244,10 +242,9 @@ class ComposeMainActivity : ComponentActivity() {
                             }
 
                             val doExport: () -> Unit  = {
-                                Log.d("EXPORT", "doExport called imageList=${state.selectedImageList.size} viewInfo=$viewInfo")
+                                Log.d("EXPORT", "doExport called imageList=${state.selectedImageList.size}")
                                 viewModel.saveImage(
                                     context.contentResolver,
-                                    viewInfo,
                                     state.selectedImageList
                                 )
                             }
@@ -413,8 +410,8 @@ class ComposeMainActivity : ComponentActivity() {
                                         viewModel.saveOutput(level = q)
                                     },
                                     onExportClick = {
-                                        Log.d("EXPORT", "click viewInfo=$viewInfo isEmpty=${viewInfo == ViewInfo.Empty} sdk=${Build.VERSION.SDK_INT}")
-                                        if (viewInfo == ViewInfo.Empty) {
+                                        Log.d("EXPORT", "click selectedImages=${state.selectedImageList.size} sdk=${Build.VERSION.SDK_INT}")
+                                        if (state.selectedImageList.isEmpty()) {
                                             return@SaveExportSheet
                                         }
                                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/main/java/me/rosuh/easywatermark/ui/MainViewModel.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/ui/MainViewModel.kt
@@ -9,7 +9,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.graphics.Matrix
 import android.graphics.Paint
 import android.net.Uri
 import android.os.Build
@@ -59,9 +58,7 @@ import me.rosuh.easywatermark.data.repo.MemorySettingRepo
 import me.rosuh.easywatermark.data.repo.TemplateRepository
 import me.rosuh.easywatermark.data.repo.UserConfigRepository
 import me.rosuh.easywatermark.data.repo.WaterMarkRepository
-import me.rosuh.easywatermark.ui.widget.WaterMarkImageView
 import me.rosuh.easywatermark.utils.FileUtils.Companion.outPutFolderName
-import me.rosuh.easywatermark.utils.bitmap.calculateInSampleSize
 import me.rosuh.easywatermark.utils.bitmap.decodeBitmapFromUri
 import me.rosuh.easywatermark.utils.bitmap.decodeSampledBitmapFromResource
 import me.rosuh.easywatermark.utils.ktx.applyConfig
@@ -137,7 +134,6 @@ class MainViewModel (
 
     val colorPalette: MutableLiveData<Palette> = MutableLiveData()
 
-    private var matrixValues = FloatArray(9)
 
     private var _viewInfoStateFlow: MutableStateFlow<ViewInfo> = MutableStateFlow(ViewInfo.Empty)
 
@@ -216,7 +212,6 @@ class MainViewModel (
 
     fun saveImage(
         contentResolver: ContentResolver,
-        viewInfo: ViewInfo,
         imageList: List<ImageInfo>,
     ) {
         viewModelScope.launch {
@@ -226,7 +221,7 @@ class MainViewModel (
             }
             saveResult.value =
                 Result.success(null, code = TYPE_SAVING)
-            val result = generateList(contentResolver, viewInfo, imageList)
+            val result = generateList(contentResolver, imageList)
             if (result.isFailure()) {
                 saveResult.value = Result.failure(null, code = TYPE_ERROR_FILE_NOT_FOUND)
                 return@launch
@@ -238,7 +233,6 @@ class MainViewModel (
 
     private suspend fun generateList(
         contentResolver: ContentResolver,
-        viewInfo: ViewInfo,
         infoList: List<ImageInfo>?,
     ): Result<List<ImageInfo>> =
         withContext(Dispatchers.Default) {
@@ -249,7 +243,7 @@ class MainViewModel (
                 try {
                     info.jobState = JobState.Ing
                     launch(Dispatchers.Main) { saveProcess.value = info }
-                    info.result = generateImage(contentResolver, viewInfo, info)
+                    info.result = generateImage(contentResolver, info)
                     info.jobState = JobState.Success(info.result!!)
                     launch(Dispatchers.Main) { saveProcess.value = info }
                 } catch (fne: FileNotFoundException) {
@@ -271,7 +265,6 @@ class MainViewModel (
 
     private suspend fun generateImage(
         contentResolver: ContentResolver,
-        viewInfo: ViewInfo,
         imageInfo: ImageInfo,
     ): Result<Uri> =
         withContext(Dispatchers.IO) {
@@ -286,12 +279,6 @@ class MainViewModel (
                     message = "Copy bitmap from uri failed."
                 )
 
-            val inSample = calculateInSampleSize(
-                mutableBitmap.width,
-                mutableBitmap.height,
-                WaterMarkImageView.calculateDrawLimitWidth(viewInfo.width, viewInfo.paddingLeft),
-                WaterMarkImageView.calculateDrawLimitHeight(viewInfo.height, viewInfo.paddingRight),
-            )
             imageInfo.width = mutableBitmap.width
             imageInfo.height = mutableBitmap.height
             val tmpConfig = waterMark.value ?: return@withContext Result.failure(
@@ -299,33 +286,8 @@ class MainViewModel (
                 code = "-1",
                 message = "config.value == null"
             )
-            imageInfo.inSample = inSample
             val canvas = Canvas(mutableBitmap)
-            // generate matrix of drawable
-            val imageMatrix = WaterMarkImageView.adjustMatrix(
-                Matrix(),
-                viewInfo.width,
-                viewInfo.height,
-                viewInfo.paddingLeft,
-                viewInfo.paddingTop,
-                imageInfo.width,
-                imageInfo.height
-            )
-            Log.i(
-                "generateImage",
-                """
-                    imageMatrix = $imageMatrix,
-                    inSample = $inSample,
-                    imageInfo = $imageInfo
-                    viewInfo = $viewInfo,
-                    bitmapW = ${mutableBitmap.width}
-                    bitmapH = ${mutableBitmap.height},
-                """.trimIndent()
-            )
-            // calculate the scale factor
-            imageMatrix.getValues(matrixValues)
-            imageInfo.scaleX = 1 / matrixValues[Matrix.MSCALE_X]
-            imageInfo.scaleY = 1 / matrixValues[Matrix.MSCALE_X]
+            // Export sizing is image-space; preview matrix values are not needed here.
             val bitmapPaint = TextPaint().applyConfig(imageInfo, tmpConfig, isScale = false)
             val layoutPaint = Paint()
             // S2a: build the cell shader through the Android renderer seam (same seam the preview
@@ -342,11 +304,12 @@ class MainViewModel (
                 }
 
                 WaterMarkRepository.MarkMode.Image -> {
+                    // Decode the icon against source-image bounds so export is independent of preview size.
                     val iconBitmapRect = decodeSampledBitmapFromResource(
                         contentResolver,
                         tmpConfig.iconUri,
-                        viewInfo.width,
-                        viewInfo.height
+                        imageInfo.width,
+                        imageInfo.height
                     )
                     if (iconBitmapRect.isFailure() || iconBitmapRect.data == null) {
                         return@withContext Result.failure(

--- a/app/src/main/java/me/rosuh/easywatermark/utils/bitmap/BitmapUtils.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/utils/bitmap/BitmapUtils.kt
@@ -8,8 +8,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.graphics.Matrix.ScaleToFit
-import android.graphics.Rect
-import android.graphics.RectF
 import android.net.Uri
 import android.provider.MediaStore
 import android.util.Log
@@ -20,7 +18,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.rosuh.easywatermark.MyApp
 import me.rosuh.easywatermark.data.model.Result
-import me.rosuh.easywatermark.data.model.ViewInfo
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.lang.ref.SoftReference
@@ -319,90 +316,6 @@ private fun getBytesInPixel(config: Bitmap.Config): Int {
     }
 }
 
-/**
- * @author hi@rosuh.me
- * @date 2021/10/16
- * Copy from [ImageView]
- */
-fun generateMatrix(
-    viewInfo: ViewInfo,
-    drawableWidth: Int,
-    drawableHeight: Int,
-    bounds: Rect,
-    tempSrc: RectF,
-    tempDst: RectF,
-): Matrix {
-    val dwidth: Int = drawableWidth
-    val dheight: Int = drawableHeight
-    val vwidth: Int = viewInfo.width - viewInfo.paddingLeft - viewInfo.paddingRight
-    val vheight: Int = viewInfo.height - viewInfo.paddingTop - viewInfo.paddingBottom
-    val fits = ((dwidth < 0 || vwidth == dwidth)
-            && (dheight < 0 || vheight == dheight))
-    var mDrawMatrix = Matrix()
-    if (dwidth <= 0 || dheight <= 0 || ScaleType.FIT_XY == viewInfo.scaleType) {
-        /* If the drawable has no intrinsic size, or we're told to
-                scaletofit, then we just fill our entire view.
-            */
-        bounds.set(0, 0, vwidth, vheight)
-    } else {
-        // We need to do the scaling ourself, so have the drawable
-        // use its native size.
-        bounds.set(0, 0, dwidth, dheight)
-        if (ScaleType.MATRIX == viewInfo.scaleType) {
-            // Use the specified matrix as-is.
-            if (!viewInfo.matrix.isIdentity) {
-                mDrawMatrix = viewInfo.matrix
-            }
-        } else if (fits) {
-            // The bitmap fits exactly, no transform needed.
-        } else if (ScaleType.CENTER == viewInfo.scaleType) {
-            // Center bitmap in view, no scaling.
-            mDrawMatrix = viewInfo.matrix
-            mDrawMatrix.setTranslate(
-                ((vwidth - dwidth) * 0.5f).roundToInt().toFloat(),
-                ((vheight - dheight) * 0.5f).roundToInt().toFloat()
-            )
-        } else if (ScaleType.CENTER_CROP == viewInfo.scaleType) {
-            mDrawMatrix = viewInfo.matrix
-            val scale: Float
-            var dx = 0f
-            var dy = 0f
-            if (dwidth * vheight > vwidth * dheight) {
-                scale = vheight.toFloat() / dheight.toFloat()
-                dx = (vwidth - dwidth * scale) * 0.5f
-            } else {
-                scale = vwidth.toFloat() / dwidth.toFloat()
-                dy = (vheight - dheight * scale) * 0.5f
-            }
-            mDrawMatrix.setScale(scale, scale)
-            mDrawMatrix.postTranslate(Math.round(dx).toFloat(), Math.round(dy).toFloat())
-        } else if (ScaleType.CENTER_INSIDE == viewInfo.scaleType) {
-            mDrawMatrix = viewInfo.matrix
-            val dx: Float
-            val dy: Float
-            val scale: Float = if (dwidth <= vwidth && dheight <= vheight) {
-                1.0f
-            } else {
-                (vwidth.toFloat() / dwidth.toFloat()).coerceAtMost(vheight.toFloat() / dheight.toFloat())
-            }
-            dx = ((vwidth - dwidth * scale) * 0.5f).roundToInt().toFloat()
-            dy = ((vheight - dheight * scale) * 0.5f).roundToInt().toFloat()
-            mDrawMatrix.setScale(scale, scale)
-            mDrawMatrix.postTranslate(dx, dy)
-        } else {
-            // Generate the required transform.
-            tempSrc.set(0f, 0f, dwidth.toFloat(), dheight.toFloat())
-            tempDst.set(0f, 0f, vwidth.toFloat(), vheight.toFloat())
-            mDrawMatrix = viewInfo.matrix
-            mDrawMatrix.setRectToRect(
-                tempSrc,
-                tempDst,
-                scaleTypeToScaleToFit(viewInfo.scaleType)
-            )
-        }
-    }
-    return mDrawMatrix
-}
 
 
 fun scaleTypeToScaleToFit(st: ScaleType): ScaleToFit {

--- a/app/src/main/java/me/rosuh/easywatermark/utils/ktx/IntExtension.kt
+++ b/app/src/main/java/me/rosuh/easywatermark/utils/ktx/IntExtension.kt
@@ -7,7 +7,8 @@ import android.content.res.Resources
 import android.graphics.Shader
 import android.os.Build
 import android.util.TypedValue
-import me.rosuh.easywatermark.ui.widget.WaterMarkImageView
+
+private const val DEFAULT_BG_ANIM_DURATION = 450L
 
 val Int.dp
     get() = TypedValue.applyDimension(
@@ -26,7 +27,7 @@ val Float.dp
 fun Int.toColor(
     toColor: Int,
     autoStart: Boolean = true,
-    duration: Long = WaterMarkImageView.ANIMATION_DURATION,
+    duration: Long = DEFAULT_BG_ANIM_DURATION,
     doOnUpdate: (it: ValueAnimator) -> Unit = {},
 ): ObjectAnimator? {
     return ObjectAnimator.ofInt(


### PR DESCRIPTION
## Summary

- Drop `ViewInfo` from the export API path (`saveImage` / `generateList` / `generateImage`).
- Remove export-only preview matrix/inSample calculations and `WaterMarkImageView` helper imports.
- Gate export by selected-image availability instead of `ViewInfo.Empty`.
- Delete dead `BitmapUtils.generateMatrix` and remove the `IntExtension` dependency on `WaterMarkImageView.ANIMATION_DURATION`.

## Scope

This is S3c-1 only. It does not replace the preview, delete `ViewInfo`, delete `WaterMarkImageView`, or redesign `WaterMarkShader`.

## Verification

- `./gradlew :app:assembleDebug :app:testDebugUnitTest --max-workers=8 --console=plain`
- `WATERMARK_GOLDEN_STRICT=true ./gradlew :app:testDebugUnitTest --tests 'me.rosuh.easywatermark.render.WatermarkExportGoldenTest' --rerun-tasks --max-workers=8 --console=plain`
- `./gradlew :app:compileDebugAndroidTestKotlin --max-workers=8 --console=plain`
- `git diff --check`

Worker also installed and launched the post-change debug APK on `emulator-5554` with no crash. Byte-level pre/post export A/B was not run because reconstructing the pre-change APK would require git stash/checkout in the worker session; text export remains covered by strict S0 and the icon decode bound change is documented as image-space behavior.

## ACSP

Accepted session: `/Users/rosu/.agent-cowork/sessions/EasyWatermark/done/20260615-082413--s3c1-export-viewinfo-decouple`
