### PR TITLE
docs: add Cursor Cloud dev-environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,14 @@ Skills are not optional reference shelves — they are the preferred playbooks f
 - **Triage labels:** `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix` (`docs/agents/triage-labels.md`).
 - **Domain docs:** vocabulary in `docs/CONTEXT.md`, decisions in `docs/adr/` (`docs/agents/domain.md`).
 - **Migration history:** high-level notes in `docs/migration-log.md`; `task_plan.md` / `findings.md` / `progress.md` at repo root are historical evidence only — do not read at session start, do not update.
+
+## Cursor Cloud specific instructions
+
+Environment is a headless Linux VM. iOS targets (`iosApp`, `:shared:iosSimulatorArm64Test`) are macOS-only and out of scope here. The in-scope work is `:app` (Android build + host unit tests), `:desktopApp` (runnable), and `:shared` tests. Standard commands are in the "Commands" section above — this section only adds non-obvious caveats.
+
+- **Toolchain (baked into the snapshot):** JDK 17 is the default `java` (via `update-alternatives`; AGP 9 needs the Gradle JVM at 17, not the VM's JDK 21). Android SDK lives at `~/android-sdk` and `local.properties` (gitignored) points `sdk.dir` there, so Gradle finds it even when `ANDROID_HOME` is unset. `JAVA_HOME`/`ANDROID_HOME` are exported in `~/.bashrc` for interactive shells.
+- **compileSdk 37 minor-version gotcha:** `Apps.compileSdk = 37` resolves to the SDK package `platforms;android-37.0` (note the `.0` minor). Install with `sdkmanager "platforms;android-37.0" "build-tools;37.0.0"` — plain `platforms;android-37` does not exist.
+- **Desktop GUI renders under software fallback:** Skiko logs `RenderException: Cannot create Linux GL context` and falls back to software rendering — this is expected on this VM and the window still works. A display is available at `DISPLAY=:1`.
+- **Running the Desktop app:** headless E2E (no display) is `./gradlew :desktopApp:run --args='--headless'` (decode → watermark → save spine, writes sample PNG/JPEG outputs under `desktopApp/build/`). For an interactive GUI preview without wrangling the native file dialog, use `./gradlew :desktopApp:run -PewmAutoOpen=<abs image path>` (optionally `-PewmW=<dp> -PewmH=<dp>`) to auto-import an image straight into the editor.
+- **`:app:lintDebug` exits non-zero** due to pre-existing findings (e.g. `NewApi`); this is not an environment break. CI runs it fail-open (`continue-on-error`), so treat a non-zero lint exit as informational.
+- **`:shared:commonPureTest`** has one test (`ContentEditorThemeTest`) that calls real `android.graphics.Bitmap.createBitmap` and fails on the plain-JVM android-host source set. It is not a CI gate. The CI gates are `:app:assembleDebug`, `:shared:desktopTest`, and `:app:testDebugUnitTest`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for EasyWatermark on a headless Linux Cloud Agent VM, and records the non-obvious startup/run caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section. No product code is changed (only `AGENTS.md`).

The environment install itself (JDK 17, Android SDK) is baked into the VM snapshot, not this diff. The recurring startup refresh is handled by the update script `./gradlew --quiet help`.

## What was installed

- **JDK 17** (OpenJDK) — set as the default `java` via `update-alternatives` (AGP 9 needs the Gradle JVM at 17; the VM shipped with JDK 21).
- **Android SDK** at `~/android-sdk`: `platform-tools`, `platforms;android-37.0`, `build-tools;37.0.0` (compileSdk 37 resolves to the `android-37.0` minor-versioned package). `local.properties` points `sdk.dir` there.

## Services / targets verified (Linux-relevant)

| Target | Command | Result |
|---|---|---|
| Shared KMP tests | `./gradlew :shared:desktopTest` | ✅ pass (CI gate) |
| Android debug build | `./gradlew :app:assembleDebug` | ✅ `app-debug.apk` (~21 MB) (CI gate) |
| Android host unit tests | `./gradlew :app:testDebugUnitTest` | ✅ pass (CI gate) |
| Desktop app (headless spine) | `./gradlew :desktopApp:run --args='--headless'` | ✅ decode → watermark → save end-to-end |
| Desktop app (GUI editor) | `./gradlew :desktopApp:run -PewmAutoOpen=<img>` | ✅ interactive editor, live preview |
| Android lint | `./gradlew :app:lintDebug` | ⚠️ runs; exits non-zero on pre-existing findings (CI runs it fail-open) |

iOS targets are macOS-only and out of scope on Linux.

## Hello-world

- **Headless:** the desktop `--headless` spine decoded a real image and rendered a tiled rotated "请勿转载 DO NOT REDISTRIBUTE" watermark, persisted config through DataStore, seeded/round-tripped the template DB, and wrote real watermarked PNG/JPEG outputs.
- **GUI:** auto-imported a sample image into the editor, changed the watermark text to `HELLO CURSOR`, and adjusted style controls (size 14→56, color gold→cyan) with the preview updating live.

## Notes

- `:shared:commonPureTest` has one non-gate test (`ContentEditorThemeTest`) that needs real `android.graphics.Bitmap` and fails on the plain-JVM host source set — pre-existing, not env-related.
- Skiko cannot create a GL context on this VM and falls back to software rendering; the desktop window still works under `DISPLAY=:1`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2be402db-a028-41f8-af32-ee4342bd4dbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2be402db-a028-41f8-af32-ee4342bd4dbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

