### PR TITLE
Enable Gradle Isolated Projects and benchmark Sync/config (ROS-100)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id(libs.plugins.ksp.get().pluginId)
 //    id(libs.plugins.hilt.plugin.get().pluginId)
     alias(libs.plugins.compose.compiler)
-    // skydoves compose-stability-analyzer 0.12.0 (Kotlin 2.4.0): @TraceRecomposition + stabilityDump.
+    // skydoves compose-stability-analyzer 0.13.0 (Kotlin 2.4.10, Isolated Projects): @TraceRecomposition + stabilityDump.
     alias(libs.plugins.stability.analyzer)
 //    id(libs.plugins.spotless.get().pluginId)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     // S4d-360: official Android-KMP library plugin for :shared (AGP 9).
     alias(libs.plugins.android.kotlin.multiplatform.library) apply false
-    // Compose stability analyzer 0.12.0 (Kotlin 2.4.0) — applied by :app for DEBUG TraceRecomposition.
+    // Compose stability analyzer 0.13.0 (Kotlin 2.4.10, Isolated Projects) — applied by :app for DEBUG TraceRecomposition.
     alias(libs.plugins.stability.analyzer) apply false
 //    alias(libs.plugins.spotless) apply false
 }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     // SQLite driver stays the `:shared` desktopMain-only `sqlite-bundled`, S4d-142).
     implementation(libs.room.runtime)
     // S4d-121: Compose Desktop UI + windowing (Skiko backend) for the minimal window. Same version the
-    // `:shared` desktopMain already uses (composeMultiplatform 1.12.0-rc01) — no version bump, no catalog change.
+    // `:shared` desktopMain already uses (composeMultiplatform 1.12.0) — no extra catalog pin.
     implementation(compose.desktop.currentOs)
     // S4d-237/S4d-360: Material3 for DesktopWindow. Explicit JetBrains Material3 1.12.0-alpha03
     // (matches :shared; avoids deprecated compose.material3 → 1.9.0 foundation skew).

--- a/docs/gradle-isolated-projects-benchmark.md
+++ b/docs/gradle-isolated-projects-benchmark.md
@@ -38,3 +38,4 @@ IDE Sync is not timed here (no Android Studio on the agent). `org.gradle.isolate
 - `compose-stability-analyzer` **0.12.0** failed Isolated Projects (`Project ':app' cannot access the tasks in the task graph that were created by other projects`).
 - **0.13.0** is Isolated Projects compatible and matches Kotlin 2.4.10.
 - Isolated Projects is still incubating in Gradle 9.7.
+- Plugin / CMP / KMP version audit: `docs/gradle-isolated-projects-compat.md`.

--- a/docs/gradle-isolated-projects-benchmark.md
+++ b/docs/gradle-isolated-projects-benchmark.md
@@ -1,0 +1,40 @@
+# Gradle Isolated Projects benchmark (ROS-100)
+
+Measured on a Cloud Agent VM: JDK 17, Android SDK 37, Gradle 9.7.0, 8 workers.
+Six Gradle projects (`:app`, `:shared`, `:desktopApp`, `:cmonet`, `:baseBenchmarks`, `:macrobenchmark`).
+
+Script: `scripts/benchmark-isolated-projects.sh`.
+Compare `--no-isolated-projects` (baseline) vs `--isolated-projects`.
+Configuration Cache, `org.gradle.parallel`, and `org.gradle.tooling.parallel` stay on in both modes.
+
+## Results
+
+Wall times. First run after `--stop` includes daemon start; later **miss** runs delete only the configuration-cache directory.
+
+| Scenario | Baseline | Isolated Projects | Delta |
+|---|---|---|---|
+| `help` miss (daemon start) | 7.8s | 6.8s | −13% |
+| `help` miss (steady) | 1.06s / 1.02s | 0.95s / 0.97s | −8% |
+| `help` hit | 0.43–0.49s | 0.43–0.48s | ~0 |
+| `:app:assembleDebug --dry-run` miss (daemon start, warmed deps) | 9.2s | 8.3s | −10% |
+| `:app:assembleDebug --dry-run` miss (steady) | 1.62s / 1.51s | 1.65s / 1.38s | ~0 to −9% |
+| `:app:assembleDebug` miss (after a successful assemble) | 10.5s | 9.3s | −11% |
+| `:app:assembleDebug` hit | 0.81s | 0.84s | ~0 |
+
+First-ever `:app:assembleDebug --dry-run` on this VM was **58s**. That run paid for AGP/Android first configuration and artifact download, not Isolated Projects. Do not use it as a before/after.
+
+Warmup `:app:assembleDebug` (baseline, first compile) was **1m 35s** (87 tasks). Later assemble miss/hit numbers above are configuration + mostly UP-TO-DATE execution.
+
+## Reading
+
+Isolated Projects helps **configuration-cache miss** (configure projects again). Hits skip configuration, so they stay the same.
+
+On this 6-module tree the miss saving is about **8–13%**, hundreds of milliseconds to ~1s. That matches the Gradle/Android write-up: the large Sync wins are for hundreds-to-thousands of modules.
+
+IDE Sync is not timed here (no Android Studio on the agent). `org.gradle.isolated-projects=true` must live in `gradle.properties` for Studio to pick it up.
+
+## Enablement notes
+
+- `compose-stability-analyzer` **0.12.0** failed Isolated Projects (`Project ':app' cannot access the tasks in the task graph that were created by other projects`).
+- **0.13.0** is Isolated Projects compatible and matches Kotlin 2.4.10.
+- Isolated Projects is still incubating in Gradle 9.7.

--- a/docs/gradle-isolated-projects-compat.md
+++ b/docs/gradle-isolated-projects-compat.md
@@ -1,0 +1,47 @@
+# Isolated Projects / Gradle 9.7 plugin compatibility (ROS-100)
+
+Audit of every **Gradle plugin** and every **CMP/KMP version pin** against Isolated Projects, Configuration Cache, and the official Kotlin/AGP matrices. Runtime-only AndroidX libraries (Coil, Koin, MaterialKolor, DataStore, …) are not Isolated Projects actors.
+
+## Stack
+
+| Piece | Pin | Official “fully supported” | Verdict |
+|---|---|---|---|
+| Gradle | 9.7.0 | Kotlin 2.4.10 max **9.5.0** | Beyond the Kotlin table. Kotlin docs allow newer Gradle with possible deprecation warnings. AGP 9.3 **requires** Gradle ≥ 9.5; Isolated Projects incubating is 9.7. Keep 9.7. |
+| AGP | 9.3.1 | Kotlin 2.4.10 max **9.1.0**; AGP 9.3 needs Gradle 9.5 | Beyond the Kotlin table, owner-authorized. Isolated Projects is part of the AGP 9.3 / Gradle 9.7 collaboration. Keep. |
+| Kotlin / KMP / Compose compiler / serialization | 2.4.10 | Current stable. Do **not** take 2.4.20-Beta (no supported KSP pair). | KGP Isolated Projects declared since 2.1.20. `kotlin-multiplatform` is listed “Broken” only for **WASM/JS** ([KT-80311](https://youtrack.jetbrains.com/issue/KT-80311)). This repo targets Android / Desktop JVM / iOS only. |
+| KSP | 2.3.11 | Isolated Projects Ready since 2.3.4 | 2.3.11 adds `org.gradle.isolated-projects` support. `ksp.project.isolation.enabled=true` is set explicitly. |
+| CMP Gradle plugin | **1.12.0** (was 1.12.0-rc01) | Latest Maven Central stable (2026-08-25) | Aligns UI/foundation/runtime with Compose BOM `2026.08.00` (1.12.0). Material3 stays `1.12.0-alpha03`. Configuration Cache fixes are already in this line. |
+| Room Gradle plugin | 2.8.4 | Isolated Projects fix landed in 2.7.0-rc02 | Applied on `:shared` only. Compatible. |
+| compose-stability-analyzer | 0.13.0 | Isolated Projects since 0.13.0 | 0.12.0 failed ROS-100 (`:app` walked the foreign task graph). |
+| Foojay toolchain resolver | 1.0.0 | Latest; required for Gradle 9 | Settings plugin. Compatible. |
+| AndroidX Compose BOM | 2026.08.00 | UI 1.12.0 | Matches CMP 1.12.0. |
+| JetBrains / androidx Material3 | 1.12.0-alpha03 / 1.5.0-alpha22 | CMP 1.12.0 published pair | Do not float to BOM stable 1.4.0. |
+| Lifecycle (KMP) | 2.11.0 | CMP 1.12.0 published pair | Compatible. |
+| Navigation Compose (Android) | 2.10.0-beta01 | Product minSdk 23; 2.10.0-rc01 is minSdk 24 | Library, not a Gradle plugin. Keep the beta pin. |
+| Coil 3 | **3.6.0** (was 3.5.0) | CMP 1.12.0 / Kotlin 2.4.10 / Skiko 0.150.1 | 3.5.0 pulled Skiko 0.144.6 and tripped CMP's desktop compatibility check. |
+| Koin BOM | 4.2.2 | KMP runtime | No Gradle plugin. |
+| MaterialKolor | 5.0.0 | CMP Material3 consumer | No Gradle plugin. |
+| DataStore | 1.3.0-alpha10 | KMP Preferences | No Gradle plugin. |
+| androidx.sqlite bundled | 2.7.0 | Room off-Android driver | Desktop/iOS only. |
+| Robolectric | 4.16.1 | Android host tests | No Gradle plugin. |
+| Benchmark / ProfileInstaller | 1.5.0-alpha07 / 1.4.1 | AGP 9 test modules | Baseline Profile Isolated Projects work landed with Room 2.7. |
+
+Unused catalog leftovers `toolsGradle=7.4.2` and `ktlintGradle=11.3.1` were removed. Neither was applied; both predate Gradle 9 / Isolated Projects.
+
+## Not in this tree
+
+- No Hilt / kapt (commented out).
+- No Spotless / ktlint plugin (commented out; Spotless Isolated Projects is only a partial fix at 8.3.0).
+- No wasm/js Kotlin targets (the published KMP Isolated Projects hole).
+
+## Proof
+
+Green under Isolated Projects on this agent (JDK 17, SDK 37):
+
+```
+./gradlew :shared:compileAndroidMain :shared:compileKotlinDesktop \
+  :cmonet:compileDebugKotlin :app:assembleDebug :desktopApp:classes \
+  :app:testDebugUnitTest :shared:desktopTest --isolated-projects
+```
+
+`BUILD SUCCESSFUL`, configuration cache stored. iOS compile stays macOS-only.

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,8 @@ android.nonFinalResIds=true
 
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true
+
+# ROS-100: Isolated Projects (Gradle 9.7 incubating). Parallel project configuration.
+# Requires Configuration Cache (already on). IDE Sync only honors this when set here,
+# not via a CLI flag. https://docs.gradle.org/current/userguide/isolated_projects.html
+org.gradle.isolated-projects=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,7 @@ org.gradle.tooling.parallel=true
 # Requires Configuration Cache (already on). IDE Sync only honors this when set here,
 # not via a CLI flag. https://docs.gradle.org/current/userguide/isolated_projects.html
 org.gradle.isolated-projects=true
+# KSP Isolated Projects path (Ready since 2.3.4). 2.3.11 also auto-enables this when
+# org.gradle.isolated-projects=true; keep the explicit flag so older wrappers / IDE
+# injections of the legacy .unsafe name still take the isolation codepath.
+ksp.project.isolation.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,9 +80,10 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 # S4d-91: Room Gradle plugin (KMP schema/codegen) — applied to :shared only for the Room KMP
 # toolchain proof. Reuses the existing room version. :app keeps classic KSP Android Room.
 androidx-room = { id = "androidx.room", version.ref = "room" }
-# skydoves compose-stability-analyzer — Kotlin 2.4.10 matches plugin 0.12.0
+# skydoves compose-stability-analyzer — Kotlin 2.4.10 matches plugin 0.13.0
 # (TraceRecomposition / DEBUG heatmap; apply on :app only).
-stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.12.0" }
+# 0.13.0 is Isolated Projects compatible (0.12.0 failed ROS-100 configuration).
+stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.13.0" }
 
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,6 @@ agp = "9.3.1"
 kotlin = "2.4.10"
 ksp = "2.3.11"
 koin-bom = "4.2.2"
-toolsGradle = "7.4.2"
-ktlintGradle = "11.3.1"
 androidxActivity = "1.13.0"
 androidxConstraintLayoutCompose = "1.1.2"
 # Keep Navigation on 2.10.0-beta01: 2.10.0-rc01 declares minSdk 24; product minSdk stays 23.
@@ -47,12 +45,15 @@ robolectric = "4.16.1"
 # stable BOM cannot force material3 back to 1.4.0 (EditorTopBar NoSuchMethodError).
 # Rollback HEAD before this Compose slice: cf847acc.
 androidxComposeBom = "2026.08.00"
-# Absolute latest CMP plugin (Maven Central), non-SNAPSHOT. Based on Compose UI 1.12.0-rc01.
-composeMultiplatform = "1.12.0-rc01"
+# CMP 1.12.0 stable (Aug 2026). Matches Compose UI/foundation/runtime 1.12.0 + BOM 2026.08.00.
+# Material3 stays 1.12.0-alpha03 (= androidx 1.5.0-alpha22). Isolated Projects / CC compatible
+# for Android/Desktop/iOS (no wasm/js targets here).
+composeMultiplatform = "1.12.0"
 accompanist = "0.37.3"
 # C3 Tier-2a (S4d-38): Coil 3 (io.coil-kt.coil3, package coil3). Compose-only; no network artifact
 # (all image models are local Uris); coil-svg dropped (SvgDecoder was never registered).
-coil = "3.5.0"
+# 3.6.0 tracks CMP 1.12.0 / Kotlin 2.4.10 / Skiko 0.150.1 (3.5.0 still pulled Skiko 0.144.6).
+coil = "3.6.0"
 # Align with CMP JetBrains material3:1.12.0-alpha03 (= androidx 1.5.0-alpha22). Do not
 # float ahead of CMP — :app BOM must not win with stable 1.4.0 either.
 material3 = "1.5.0-alpha22"

--- a/scripts/benchmark-isolated-projects.sh
+++ b/scripts/benchmark-isolated-projects.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# ROS-100: compare Gradle configuration / assemble with and without Isolated Projects.
+# Usage: scripts/benchmark-isolated-projects.sh [outdir]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-"$ROOT/build/isolated-projects-bench"}"
+JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+export JAVA_HOME
+export ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+mkdir -p "$OUT"
+cd "$ROOT"
+
+GRADLEW=(./gradlew --max-workers=8 --console=plain --no-daemon)
+# Drop noisy progress; keep BUILD SUCCESSFUL / configuration-cache / isolated lines.
+FILTER='BUILD SUCCESSFUL|BUILD FAILED|Configuration cache|Isolated projects|Calculating task graph|Reusing configuration cache|Configuring|FAILURE|problems were found'
+
+log() { printf '%s\n' "$*" | tee -a "$OUT/run.log"; }
+
+run_one() {
+  local mode="$1"   # baseline | isolated
+  local scenario="$2" # help-miss | help-hit | dryrun-miss | assemble-miss | assemble-hit
+  local idx="$3"
+  local extra_flag
+  case "$mode" in
+    baseline) extra_flag="--no-isolated-projects" ;;
+    isolated) extra_flag="--isolated-projects" ;;
+    *) echo "bad mode: $mode" >&2; return 1 ;;
+  esac
+
+  local task_args=()
+  case "$scenario" in
+    help-miss|help-hit) task_args=(help) ;;
+    dryrun-miss) task_args=(:app:assembleDebug --dry-run) ;;
+    assemble-miss|assemble-hit) task_args=(:app:assembleDebug) ;;
+    *) echo "bad scenario: $scenario" >&2; return 1 ;;
+  esac
+
+  if [[ "$scenario" == *-miss ]]; then
+    rm -rf "$ROOT/.gradle/configuration-cache" "$ROOT/.gradle/configuration-cache-report"
+  fi
+
+  local stamp
+  stamp="$(date +%Y%m%dT%H%M%S)"
+  local raw="$OUT/${mode}-${scenario}-${idx}-${stamp}.log"
+  local start end elapsed
+  start="$(date +%s.%N)"
+  set +e
+  "${GRADLEW[@]}" "$extra_flag" "${task_args[@]}" >"$raw" 2>&1
+  local rc=$?
+  set -e
+  end="$(date +%s.%N)"
+  elapsed="$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.3f", e - s }')"
+
+  local gradle_line
+  gradle_line="$(grep -E 'BUILD (SUCCESSFUL|FAILED) in' "$raw" | tail -n1 || true)"
+  local cc_line
+  cc_line="$(grep -E 'Configuration cache entry|Reusing configuration cache|Calculating task graph' "$raw" | tail -n1 || true)"
+  local problems
+  problems="$(grep -E 'problems were found|Isolated Projects' "$raw" | head -n5 || true)"
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$mode" "$scenario" "$idx" "$elapsed" "$rc" "$gradle_line" \
+    | tee -a "$OUT/summary.tsv"
+  {
+    echo "---- $mode $scenario #$idx  wall=${elapsed}s  rc=$rc"
+    echo "$gradle_line"
+    echo "$cc_line"
+    echo "$problems"
+  } | tee -a "$OUT/run.log"
+
+  grep -E "$FILTER" "$raw" >>"$OUT/filtered.log" || true
+  return 0
+}
+
+{
+  echo "mode	scenario	idx	wall_s	rc	gradle"
+} >"$OUT/summary.tsv"
+: >"$OUT/run.log"
+: >"$OUT/filtered.log"
+
+log "JAVA_HOME=$JAVA_HOME"
+log "ANDROID_HOME=$ANDROID_HOME"
+log "started $(date -Is)"
+
+# Warm wrapper + dependency caches once (not timed).
+log "warmup: help --no-isolated-projects"
+"${GRADLEW[@]}" --no-isolated-projects help >"$OUT/warmup-help.log" 2>&1 || true
+
+for mode in baseline isolated; do
+  for i in 1 2 3; do
+    run_one "$mode" help-miss "$i"
+    run_one "$mode" help-hit "$i"
+  done
+  run_one "$mode" dryrun-miss 1
+done
+
+# Full assemble: one warmup then miss/hit per mode.
+log "warmup: assembleDebug --no-isolated-projects"
+"${GRADLEW[@]}" --no-isolated-projects :app:assembleDebug >"$OUT/warmup-assemble.log" 2>&1 || true
+
+for mode in baseline isolated; do
+  run_one "$mode" assemble-miss 1
+  run_one "$mode" assemble-hit 1
+done
+
+log "finished $(date -Is)"
+log "summary: $OUT/summary.tsv"

--- a/scripts/benchmark-isolated-projects.sh
+++ b/scripts/benchmark-isolated-projects.sh
@@ -106,6 +106,7 @@ log "warmup: assembleDebug --no-isolated-projects"
 "${GRADLEW[@]}" --no-isolated-projects :app:assembleDebug >"$OUT/warmup-assemble.log" 2>&1 || true
 
 for mode in baseline isolated; do
+  ./gradlew --stop >/dev/null 2>&1 || true
   run_one "$mode" assemble-miss 1
   run_one "$mode" assemble-hit 1
 done

--- a/scripts/benchmark-isolated-projects.sh
+++ b/scripts/benchmark-isolated-projects.sh
@@ -14,7 +14,9 @@ export PATH="$JAVA_HOME/bin:$PATH"
 mkdir -p "$OUT"
 cd "$ROOT"
 
-GRADLEW=(./gradlew --max-workers=8 --console=plain --no-daemon)
+# Daemon stays up within a mode so config-cache hits are realistic.
+# Stop between modes so Isolated Projects / baseline do not share a tainted daemon.
+GRADLEW=(./gradlew --max-workers=8 --console=plain)
 # Drop noisy progress; keep BUILD SUCCESSFUL / configuration-cache / isolated lines.
 FILTER='BUILD SUCCESSFUL|BUILD FAILED|Configuration cache|Isolated projects|Calculating task graph|Reusing configuration cache|Configuring|FAILURE|problems were found'
 
@@ -91,6 +93,7 @@ log "warmup: help --no-isolated-projects"
 "${GRADLEW[@]}" --no-isolated-projects help >"$OUT/warmup-help.log" 2>&1 || true
 
 for mode in baseline isolated; do
+  ./gradlew --stop >/dev/null 2>&1 || true
   for i in 1 2 3; do
     run_one "$mode" help-miss "$i"
     run_one "$mode" help-hit "$i"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

[ROS-100](https://linear.app/rosu/issue/ROS-100/开启-gradle-isolated-projects-并做配置构建基准测试) — Gradle 9.7 Isolated Projects (parallel configuration / IDE Sync). See [the WeChat write-up](https://mp.weixin.qq.com/s/Z4iF_mavSWX7FYQxRrDHaQ) and [Gradle Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html).

`feat/migrate_to_compose` already ships Gradle 9.7.0, Configuration Cache, `org.gradle.parallel`, and `org.gradle.tooling.parallel`. Isolated Projects was the missing switch.

## Change

- Set `org.gradle.isolated-projects=true` and `ksp.project.isolation.enabled=true` in `gradle.properties`.
- Bump `compose-stability-analyzer` **0.12.0 → 0.13.0** (0.12.0 walked the foreign task graph).
- Bump CMP plugin **1.12.0-rc01 → 1.12.0** (stable, matches Compose UI 1.12.0 / BOM `2026.08.00`).
- Bump Coil **3.5.0 → 3.6.0** (Kotlin 2.4.10 + Skiko 0.150.1; 3.5.0 tripped CMP desktop Skiko 0.144.6 vs 0.150.1).
- Drop unused catalog pins `toolsGradle=7.4.2` / `ktlintGradle=11.3.1`.
- Benchmark script + numbers: `docs/gradle-isolated-projects-benchmark.md`.
- Plugin / CMP / KMP audit: `docs/gradle-isolated-projects-compat.md`.

## Compatibility (what stayed, what moved)

Kotlin 2.4.10’s official “fully supported” window is Gradle **≤ 9.5.0** and AGP **≤ 9.1.0**. This branch is already on Gradle **9.7.0** + AGP **9.3.1** (AGP 9.3 needs Gradle ≥ 9.5; Isolated Projects incubating is 9.7). Kotlin docs allow newer Gradle/AGP with possible deprecation warnings. Do **not** take Kotlin 2.4.20-Beta (no supported KSP pair).

`kotlin-multiplatform` is listed Isolated-Projects “Broken” only for **WASM/JS**. This repo has Android / Desktop JVM / iOS only.

Room 2.8.4, KSP 2.3.11, Foojay 1.0.0, Lifecycle 2.11.0, Material3 `1.12.0-alpha03` stay.

## Proof

```
./gradlew :shared:compileAndroidMain :shared:compileKotlinDesktop \
  :cmonet:compileDebugKotlin :app:assembleDebug :desktopApp:classes \
  :app:testDebugUnitTest :shared:desktopTest --isolated-projects
```

`BUILD SUCCESSFUL` (114 tasks), configuration cache stored. After Coil 3.6.0 the CMP desktop Skiko warning is gone.

## Benchmark (6 modules, JDK 17)

Isolated Projects helps **configuration-cache miss** only (~8–13% here). Hits unchanged. Article-scale Sync wins need hundreds of modules. Studio Sync was not timed on the agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05023-d1e3-795a-adbe-f4bb56187c11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05023-d1e3-795a-adbe-f4bb56187c11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

