### PR TITLE
fix(ci): export WIX_PATH so Isolated Projects does not break Windows …

### DIFF
--- a/.github/workflows/desktop_packaging.yml
+++ b/.github/workflows/desktop_packaging.yml
@@ -174,9 +174,19 @@ jobs:
           }
           function Export-WixBinDir([string]$dir) {
             $env:PATH = "$dir;$env:PATH"
+            # CMP 1.12.0 configureWix() (Windows-only) reads WIX_PATH at configuration
+            # time and returns before touching rootProject.layout. Isolated Projects
+            # forbids that cross-project layout access (master packaging run
+            # 33823548228). PATH alone is not enough — the plugin does not consult it
+            # during configuration.
+            $env:WIX_PATH = $dir
             if ($env:GITHUB_PATH) {
               Add-Content -Path $env:GITHUB_PATH -Value $dir
               Write-Host "Exported WiX bin to GITHUB_PATH: $dir"
+            }
+            if ($env:GITHUB_ENV) {
+              Add-Content -Path $env:GITHUB_ENV -Value "WIX_PATH=$dir"
+              Write-Host "Exported WIX_PATH to GITHUB_ENV: $dir"
             }
           }
           $bin = Get-WixBinDir
@@ -211,6 +221,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            if [[ -z "${WIX_PATH:-}" || ! -d "$WIX_PATH" ]]; then
+              echo "FAIL: WIX_PATH must be a directory so CMP configureWix() does not touch rootProject.layout under Isolated Projects" >&2
+              echo "WIX_PATH=${WIX_PATH:-<unset>}" >&2
+              exit 1
+            fi
+            echo "WIX_PATH=$WIX_PATH"
+          fi
           ${{ matrix.gradle }} :desktopApp:packageDistributionForCurrentOS --max-workers=4
           ${{ matrix.gradle }} :desktopApp:createDistributable --max-workers=4
 

--- a/docs/gradle-isolated-projects-compat.md
+++ b/docs/gradle-isolated-projects-compat.md
@@ -34,6 +34,14 @@ Unused catalog leftovers `toolsGradle=7.4.2` and `ktlintGradle=11.3.1` were remo
 - No Spotless / ktlint plugin (commented out; Spotless Isolated Projects is only a partial fix at 8.3.0).
 - No wasm/js Kotlin targets (the published KMP Isolated Projects hole).
 
+## Known hole: Windows MSI / WiX
+
+CMP 1.12.0 `configureWix()` (Windows-only) writes the downloaded WiX toolset into `rootProject.layout.buildDirectory`. Isolated Projects forbids that cross-project `Project.layout` access, so `:desktopApp:packageDistributionForCurrentOS` fails at configuration on Windows while Linux DEB and macOS DMG stay green (master run [33823548228](https://github.com/rosuH/EasyWatermark/actions/runs/33823548228)).
+
+The plugin returns early when `WIX_PATH` is a real directory. Desktop packaging CI already installs WiX via Chocolatey; it must export that bin dir as `WIX_PATH` (not only `PATH`). Local Windows packaging under Isolated Projects needs the same env var, or `--no-isolated-projects`.
+
+Do not turn Isolated Projects off in `gradle.properties` for this. The hole is CMP's, not a reason to drop parallel configuration.
+
 ## Proof
 
 Green under Isolated Projects on this agent (JDK 17, SDK 37):


### PR DESCRIPTION
…MSI packaging

CMP configureWix() writes WiX into rootProject.layout unless WIX_PATH is set. PATH alone is not enough, so Windows packaging failed after Isolated Projects landed while Linux and macOS stayed green.